### PR TITLE
Scroll down scrolling region with CSI n S sequence.

### DIFF
--- a/client/mosh-client/terminal/terminaldisplay.cc
+++ b/client/mosh-client/terminal/terminaldisplay.cc
@@ -243,7 +243,8 @@ std::string Display::new_frame( bool initialized, const Framebuffer &last, const
 	  frame.append_silent_move( bottom_margin, 0 );
 
 	  /* scroll */
-	  frame.append( lines_scrolled, '\n' );
+      snprintf( tmp, 64, "\033[%dS", lines_scrolled);
+      frame.append( tmp );
 
 	  /* reset scrolling region */
 	  frame.append( "\033[r" );


### PR DESCRIPTION
Resolves issue https://github.com/jumptrading/FluentTerminal/issues/62

Usage of new lined character `\n` to scroll down "scrolling region" on Windows Console causes randomly appearing flickering.

To avoid above issue special `CSI n S` sequence to scroll for `n` lines is used ( similar what OpenSSH does in similar situations ).