### PR TITLE
Clean up error handling

### DIFF
--- a/mosh_cs/Program.cs
+++ b/mosh_cs/Program.cs
@@ -6,6 +6,22 @@ using System.Text.RegularExpressions;
 
 namespace mosh
 {
+
+    class InvalidArgsException : Exception
+    {
+        public InvalidArgsException(string message) : base(message) { }
+    }
+
+    class ConnectionError : Exception
+    {
+        public ConnectionError(string message) : base(message) { }
+    }
+
+    enum ExitCode {
+        InvalidArgs = 254,
+        ConnectionError = 255,
+    }
+
     class Program
     {
         private const string DefaultMoshPortRange = "60000:60050";
@@ -23,137 +39,89 @@ namespace mosh
         /// If mosh ports range argument isn't specified, it will default to <c>60000:60050</c>.</param>
         /// <returns>Return codes:
         /// <list type="bullet">
-        /// <item>0 - Success;</item>
-        /// <item>1 - Invalid arguments;</item>
-        /// <item>2 - mosh-client.exe not found;</item>
-        /// <item>100 - Other exception.</item>
+        /// <item>254 - Invalid command line arguments.</item>
+        /// <item>255 - Initial SSH or Mosh connection setup failed.</item>
+        /// <item>All other values - Exit code returned by remote shell.</item>
         /// </list>
         /// </returns>
         static int Main(string[] args)
         {
+            try
+            {
+                return Run(args);
+            } catch (InvalidArgsException e) {
+                Console.Write(e.Message);
+                return (int)ExitCode.InvalidArgs;
+            } catch (Exception e)
+            {
+                Console.Write(e.Message);
+                return (int)ExitCode.ConnectionError;
+            }
+        }
+
+        static int Run(string[] args)
+        {
             if (string.IsNullOrEmpty(MoshClientWrapper.MoshClientExePath))
             {
-                Console.Error.WriteLine("mosh-client.exe file cannot be found. Possible solutions are:");
-                Console.Error.WriteLine($"  - Specify full file path in appSettings section of mosh.config file, with key \"{MoshClientWrapper.MoshClientAppSettingsKey}\";");
-                Console.Error.WriteLine($"  - Copy mosh-client.exe file (with this exact name) into the current working directory;");
-                Console.Error.WriteLine($"  - Copy mosh-client.exe file (with this exact name) into the same directory where current executable (mosh.exe) is.");
-
-                WaitForEnter();
-
-                return 2;
+                throw new ConnectionError(String.Join(
+                    Environment.NewLine,
+                    "mosh-client.exe file cannot be found. Possible solutions are:",
+                    $"  - Specify full file path in appSettings section of mosh.config file, with key \"{MoshClientWrapper.MoshClientAppSettingsKey}\"",
+                    $"  - Copy mosh-client.exe file (with this exact name) into the current working directory",
+                    $"  - Copy mosh-client.exe file (with this exact name) into the same directory where current executable (mosh.exe) is."
+                ));
             }
 
             List<string> argList = args.ToList();
 
             string moshPortRange = argList.LastOrDefault();
-
             if (moshPortRange == null)
             {
-                Console.Error.WriteLine("At least user and host have to be specified.");
-                WaitForEnter();
-
-                return 1;
+                throw new InvalidArgsException("At least user and host have to be specified.");
             }
 
             if (MoshPortRangeRx.IsMatch(moshPortRange))
             {
                 argList.RemoveAt(argList.Count - 1);
-
                 moshPortRange = moshPortRange.Trim();
             }
             else
+            {
                 moshPortRange = DefaultMoshPortRange;
+            }
 
             Match userHostMatch = argList.Select(arg => UserHostRx.Match(arg)).FirstOrDefault(m => m.Success);
-
             if (userHostMatch == null)
             {
-                Console.Error.WriteLine("Determining user and host from the specified arguments failed.");
-                WaitForEnter();
-
-                return 1;
+                throw new InvalidArgsException("Determining user and host from the specified arguments failed");
             }
 
             string sshArgs = string.Join(" ", argList.Select(QuoteIfNeeded));
 
-            Tuple<string, string> moshPortAndKey;
-
-            try
-            {
-                moshPortAndKey = SshAuthenticator.GetMoshPortAndKey(sshArgs, moshPortRange);
-            }
-            catch (Exception ex)
-            {
-                Console.Error.WriteLine(ex.Message);
-                WaitForEnter();
-
-                return 100;
-            }
-
+            var moshPortAndKey = SshAuthenticator.GetMoshPortAndKey(sshArgs, moshPortRange);
             if (moshPortAndKey == null)
             {
-                Console.Error.WriteLine("Remote server has not returned a valid MOSH CONNECT response.");
-                WaitForEnter();
-
-                return 100;
+                throw new ConnectionError("Remote server has not returned a valid MOSH CONNECT response.");
             }
 
             Console.Clear();
 
             string strHost = userHostMatch.Groups["host"].Value;
-
             if (!IPAddress.TryParse(strHost, out IPAddress host))
             {
                 IPHostEntry hostInfo;
-
-                try
-                {
-                    hostInfo = Dns.GetHostEntry(strHost);
-                }
-                catch (Exception ex)
-                {
-                    Console.Error.WriteLine($"Failed to resolve host '{strHost}'. Exception: {ex.Message}");
-                    WaitForEnter();
-
-                    return 1;
-                }
-
+                hostInfo = Dns.GetHostEntry(strHost);
                 host = hostInfo.AddressList.FirstOrDefault();
-
                 if (host == null)
                 {
-                    Console.Error.WriteLine($"Failed to resolve host '{strHost}'.");
-                    WaitForEnter();
-
-                    return 1;
+                    throw new ConnectionError($"Failed to resolve host '{strHost}'.");
                 }
             }
 
-            int exitCode;
-
-            try
-            {
-                exitCode = MoshClientWrapper.StartMoshSession(userHostMatch.Groups["user"].Value, host,
+            return MoshClientWrapper.StartMoshSession(userHostMatch.Groups["user"].Value, host,
                     moshPortAndKey.Item1, moshPortAndKey.Item2);
-            }
-            catch (Exception e)
-            {
-                Console.Error.WriteLine(e.Message);
-                WaitForEnter();
-
-                return 100;
-            }
-
-            if (exitCode != 0)
-            {
-                Console.Error.WriteLine($"mosh-client.exe exited with code {exitCode}.");
-                WaitForEnter();
-
-                return 100;
-            }
-
-            return 0;
         }
+
 
         private static string QuoteIfNeeded(string input)
         {
@@ -163,16 +131,6 @@ namespace mosh
             input = input.Replace("\"", "\"\"");
 
             return string.Concat("\"", input, "\"");
-        }
-
-        private static void WaitForEnter()
-        {
-            // Ensuring that user sees the error is done in a different way in release.
-#if DEBUG
-            Console.WriteLine();
-            Console.WriteLine("Press [Enter] to exit.");
-            Console.ReadLine();
-#endif
         }
     }
 }

--- a/mosh_cs/Program.cs
+++ b/mosh_cs/Program.cs
@@ -22,7 +22,7 @@ namespace mosh
         /// with one optional argument added at the very end: mosh ports range in format <c>#####:#####</c> (i.e. <c>60000:60050</c>).
         /// If mosh ports range argument isn't specified, it will default to <c>60000:60050</c>.</param>
         /// <returns>Return codes:
-        /// <list type="bulet">
+        /// <list type="bullet">
         /// <item>0 - Success;</item>
         /// <item>1 - Invalid arguments;</item>
         /// <item>2 - mosh-client.exe not found;</item>


### PR DESCRIPTION
- Use exceptions (caught at the top level) instead catching errors at every place they are generated
- Use 255 and 254 exit codes for mosh specific errors to minimise clashes with remote shell exit code codes
- Removed WaitForEnter - it's not longer needed