### PR TITLE
Many clean ups

### DIFF
--- a/mosh_cs/MoshClientWrapper.cs
+++ b/mosh_cs/MoshClientWrapper.cs
@@ -66,20 +66,20 @@ namespace mosh
 
         internal int Start(string moshUser, IPAddress host, string moshPort, string moshKey)
         {
-            using (Process sshProcess = new Process())
+            using (Process clientProcess = new Process())
             {
-                sshProcess.StartInfo.FileName = MoshClientExePath;
-                sshProcess.StartInfo.UseShellExecute = false;
-                sshProcess.StartInfo.RedirectStandardInput = false;
-                sshProcess.StartInfo.RedirectStandardOutput = false;
-                sshProcess.StartInfo.RedirectStandardError = false;
-                sshProcess.StartInfo.Arguments = $"{host} {moshPort}";
-                sshProcess.StartInfo.EnvironmentVariables.Add("MOSH_KEY", moshKey);
-                sshProcess.StartInfo.EnvironmentVariables.Add("MOSH_USER", moshUser);
+                clientProcess.StartInfo.FileName = MoshClientExePath;
+                clientProcess.StartInfo.UseShellExecute = false;
+                clientProcess.StartInfo.RedirectStandardInput = false;
+                clientProcess.StartInfo.RedirectStandardOutput = false;
+                clientProcess.StartInfo.RedirectStandardError = false;
+                clientProcess.StartInfo.Arguments = $"{host} {moshPort}";
+                clientProcess.StartInfo.EnvironmentVariables.Add("MOSH_KEY", moshKey);
+                clientProcess.StartInfo.EnvironmentVariables.Add("MOSH_USER", moshUser);
 
-                sshProcess.Start();
-                sshProcess.WaitForExit();
-                return sshProcess.ExitCode;
+                clientProcess.Start();
+                clientProcess.WaitForExit();
+                return clientProcess.ExitCode;
             }
         }
 

--- a/mosh_cs/MoshClientWrapper.cs
+++ b/mosh_cs/MoshClientWrapper.cs
@@ -9,12 +9,12 @@ namespace mosh
 {
     class MoshClientNotFound : Exception
     {
-        public MoshClientNotFound(string message) : base("mosh client not found:" + message) { }
+        public MoshClientNotFound(string message) : base(message) { }
     }
 
     internal class MoshClientWrapper
     {
-        internal const string MoshClientAppSettingsKey = "mosh-client";
+        private const string MoshClientAppSettingsKey = "mosh-client";
         private const string MoshClientExeName = "mosh-client.exe";
 
         private readonly string MoshClientExePath;
@@ -35,11 +35,17 @@ namespace mosh
             path = new FileInfo(Assembly.GetExecutingAssembly().Location).Directory?.FullName;
             if (string.IsNullOrEmpty(path))
             {
-                throw new MoshClientNotFound("Could not determine program name");
+                throw new MoshClientNotFound($"Could not determine program name while looking for {MoshClientExeName}");
             }
             path = Path.Combine(path, MoshClientExeName);
             if (!File.Exists(path)) {
-                throw new MoshClientNotFound("not adjacent to mosh.exe");
+                throw new MoshClientNotFound(String.Join(
+                    Environment.NewLine,
+                    $"{MoshClientExeName} file cannot be found. Possible solutions are:",
+                    $"  - Specify full file path in appSettings section of mosh.config file, with key \"{MoshClientAppSettingsKey}\"",
+                    $"  - Copy {MoshClientExeName} file (with this exact name) into the current working directory",
+                    $"  - Copy {MoshClientExeName} file (with this exact name) into the same directory where current executable (mosh.exe) is."
+                ));
             }
             return path;
         }

--- a/mosh_cs/MoshClientWrapper.cs
+++ b/mosh_cs/MoshClientWrapper.cs
@@ -64,7 +64,7 @@ namespace mosh
             return path;
         }
 
-        internal int Start(string moshUser, IPAddress host, string moshPort, string moshKey)
+        internal int Start(string user, IPAddress host, string moshPort, string moshKey)
         {
             using (Process clientProcess = new Process())
             {
@@ -75,7 +75,7 @@ namespace mosh
                 clientProcess.StartInfo.RedirectStandardError = false;
                 clientProcess.StartInfo.Arguments = $"{host} {moshPort}";
                 clientProcess.StartInfo.EnvironmentVariables.Add("MOSH_KEY", moshKey);
-                clientProcess.StartInfo.EnvironmentVariables.Add("MOSH_USER", moshUser);
+                clientProcess.StartInfo.EnvironmentVariables.Add("MOSH_USER", user);
 
                 clientProcess.Start();
                 clientProcess.WaitForExit();

--- a/mosh_cs/Program.cs
+++ b/mosh_cs/Program.cs
@@ -24,7 +24,7 @@ namespace mosh
 
     class Program
     {
-        private const string DefaultMoshPortRange = "60000:60050";
+        private const string DefaultMoshPortRange = "60000:60999";
 
         private static readonly Regex ShouldQuoteRx = new Regex("[\\s\"]", RegexOptions.Compiled);
         private static readonly Regex MoshPortRangeRx = new Regex(@"^\s*\d{1,5}:\d{1,5}\s*");
@@ -36,7 +36,7 @@ namespace mosh
         /// <param name="args">
         /// Input arguments are the same as for OpenSSH (<see cref="!https://man.openbsd.org/ssh">https://man.openbsd.org/ssh</see>),
         /// with one optional argument added at the very end: mosh ports range in format <c>#####:#####</c> (i.e. <c>60000:60050</c>).
-        /// If mosh ports range argument isn't specified, it will default to <c>60000:60050</c>.</param>
+        /// If mosh ports range argument isn't specified, it will default to <c>60000:60099</c>.</param>
         /// <returns>Return codes:
         /// <list type="bullet">
         /// <item>254 - Invalid command line arguments.</item>

--- a/mosh_cs/Program.cs
+++ b/mosh_cs/Program.cs
@@ -61,8 +61,11 @@ namespace mosh
 
         static int Run(string[] args)
         {
-            if (string.IsNullOrEmpty(MoshClientWrapper.MoshClientExePath))
+            MoshClientWrapper moshClient;
+            try
             {
+                moshClient = new MoshClientWrapper();
+            } catch (MoshClientNotFound) { 
                 throw new ConnectionError(String.Join(
                     Environment.NewLine,
                     "mosh-client.exe file cannot be found. Possible solutions are:",
@@ -118,7 +121,7 @@ namespace mosh
                 }
             }
 
-            return MoshClientWrapper.StartMoshSession(userHostMatch.Groups["user"].Value, host,
+            return moshClient.Start(userHostMatch.Groups["user"].Value, host,
                     moshPortAndKey.Item1, moshPortAndKey.Item2);
         }
 

--- a/mosh_cs/Program.cs
+++ b/mosh_cs/Program.cs
@@ -61,19 +61,7 @@ namespace mosh
 
         static int Run(string[] args)
         {
-            MoshClientWrapper moshClient;
-            try
-            {
-                moshClient = new MoshClientWrapper();
-            } catch (MoshClientNotFound) { 
-                throw new ConnectionError(String.Join(
-                    Environment.NewLine,
-                    "mosh-client.exe file cannot be found. Possible solutions are:",
-                    $"  - Specify full file path in appSettings section of mosh.config file, with key \"{MoshClientWrapper.MoshClientAppSettingsKey}\"",
-                    $"  - Copy mosh-client.exe file (with this exact name) into the current working directory",
-                    $"  - Copy mosh-client.exe file (with this exact name) into the same directory where current executable (mosh.exe) is."
-                ));
-            }
+            var moshClient = new MoshClientWrapper();
 
             List<string> argList = args.ToList();
 

--- a/mosh_cs/Program.cs
+++ b/mosh_cs/Program.cs
@@ -102,11 +102,6 @@ namespace mosh
             string sshArgs = string.Join(" ", argList.Select(QuoteIfNeeded));
 
             var moshPortAndKey = SshAuthenticator.GetMoshPortAndKey(sshArgs, moshPortRange);
-            if (moshPortAndKey == null)
-            {
-                throw new ConnectionError("Remote server has not returned a valid MOSH CONNECT response.");
-            }
-
             Console.Clear();
 
             string strHost = userHostMatch.Groups["host"].Value;

--- a/mosh_cs/Program.cs
+++ b/mosh_cs/Program.cs
@@ -101,7 +101,7 @@ namespace mosh
 
             string sshArgs = string.Join(" ", argList.Select(QuoteIfNeeded));
 
-            var moshPortAndKey = SshAuthenticator.GetMoshPortAndKey(sshArgs, moshPortRange);
+            var portAndKey = SshAuthenticator.GetMoshPortAndKey(sshArgs, moshPortRange);
             Console.Clear();
 
             string strHost = userHostMatch.Groups["host"].Value;
@@ -116,8 +116,7 @@ namespace mosh
                 }
             }
 
-            return moshClient.Start(userHostMatch.Groups["user"].Value, host,
-                    moshPortAndKey.Item1, moshPortAndKey.Item2);
+            return moshClient.Start(userHostMatch.Groups["user"].Value, host, portAndKey.Port, portAndKey.Key);
         }
 
 

--- a/mosh_cs/SshAuthenticator.cs
+++ b/mosh_cs/SshAuthenticator.cs
@@ -6,6 +6,18 @@ using System.Threading;
 
 namespace mosh
 {
+    struct PortKeyPair
+    {
+        public string Port;
+        public string Key;
+
+        public PortKeyPair(string port, string key)
+        {
+            Port = port;
+            Key = key;
+        }
+    } 
+
     internal static class SshAuthenticator
     {
         private static readonly Regex MoshConnectRx =
@@ -24,9 +36,9 @@ namespace mosh
             return Path.Combine(system32Folder, @"OpenSSH\ssh.exe");
         }
 
-        internal static Tuple<string,string> GetMoshPortAndKey(string sshArgs, string moshPortRange)
+        internal static PortKeyPair GetMoshPortAndKey(string sshArgs, string moshPortRange)
         {
-            Tuple<string, string> portAndKey = null;
+            PortKeyPair? portAndKey = null;
 
             using (Process sshProcess = new Process())
             {
@@ -44,7 +56,7 @@ namespace mosh
                     Match match = MoshConnectRx.Match(line);
                     if (match.Success)
                     {
-                        portAndKey = Tuple.Create(match.Groups["mosh_port"].Value, match.Groups["mosh_key"].Value);
+                        portAndKey = new PortKeyPair(match.Groups["mosh_port"].Value, match.Groups["mosh_key"].Value);
                     }
                 }
                 sshProcess.WaitForExit();
@@ -53,7 +65,7 @@ namespace mosh
                 {
                     throw new ConnectionError("Remote server has not returned a valid MOSH CONNECT response.");
                 }
-                return portAndKey;
+                return (PortKeyPair)portAndKey;
             }
         }
     }


### PR DESCRIPTION
- Use the correct default mosh port range
- Make MoshClientWrapper's interface simpler. There was no need for Main to reach into a lazy variable inside MoshClientWrapper.
- Fix the name for the mosh-client Process instance. It was confusingly named "sshProcess" but was not related to SSH.
- Read mosh-server output synchronously. This avoids the need for the hacky thread sleep and the lock.
- Have GetMoshPortAndKey raise an exception if things fail so the caller doesn't have to check for errors.
- Use a more convenient type for storing the mosh port and key
- Simplify error handling for mosh-client search further
  - Main no longer needs to check for errors if mosh-client.exe can't be found
  - MoshCientAppSettingsKey doesn't need to exposed
  - Use exe name const in error message
- Clean up Main by extracting DNS resolution